### PR TITLE
style:updated the project leads dropdown to include new hires

### DIFF
--- a/components/createProject.jsx
+++ b/components/createProject.jsx
@@ -190,7 +190,7 @@ export default function CreateProject({ toggle }) {
                           className="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-gray-500 focus:border-gray-500 sm:text-sm"
                         >
                           <option defaultValue>Select</option>
-                          <option>Treasure-Prasie</option>
+                          <option>Treasure-Praise</option>
                           <option>Maryam Salaudeen</option>
                           <option>Kayode Adedeji</option>
                           <option>Alex</option>


### PR DESCRIPTION
### My PR fixes the problem of new hires' names not reflecting on the Project lead dropdown


<img width="1440" alt="Screenshot 2023-01-23 at 3 15 49 PM" src="https://user-images.githubusercontent.com/25864587/214068758-cacc2538-8b00-402d-a2cc-94b5b6a55616.png">



### Changes Proposed
This could be done better if there was a single source of truth for employee details. This would avoid manual imputation

### What were you told to do ?
Make the Dropdown reflect recent company hires and remove exited staff

### Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the Pull Request are clear and explain the approach.
- [x] I am making a pull request against the dev branch and sync fork.
- [x] My commit messages styles match our requested structure.
- [x] My code additions will fail neither code linting checks nor unit tests.
- [x] I am only making changes to files I was requested to

### Solution
<img width="461" alt="Screenshot 2023-01-23 at 3 48 57 PM" src="https://user-images.githubusercontent.com/25864587/214069376-433cc267-4e2c-4fe0-a1ef-f18e5de3f5ce.png">



